### PR TITLE
Remove max-width and padding from #root to use full screen width

### DIFF
--- a/document-intelligence-frontend/src/App.css
+++ b/document-intelligence-frontend/src/App.css
@@ -1,7 +1,7 @@
 #root {
-  max-width: 1280px;
+  /* max-width: 1280px; */
   margin: 0 auto;
-  padding: 2rem;
+  /* padding: 2rem; */
   text-align: center;
 }
 


### PR DESCRIPTION
- Comment out max-width: 1280px to allow full screen width
- Comment out padding: 2rem to eliminate container padding
- Application now occupies the entire screen width as requested